### PR TITLE
Add alert recipes for workflow and issue alerts

### DIFF
--- a/skills/bd-cli/SKILL.md
+++ b/skills/bd-cli/SKILL.md
@@ -89,6 +89,8 @@ This skill includes reference files, recipes, and runbooks for domain-specific t
 | Fetch and analyze session timelines | [recipes/sessions.md](recipes/sessions.md) | When to use `timeline search` vs `timeline logs`, hydration, search patterns, pitfalls |
 | Browse crash reports and issue groups | [recipes/issues.md](recipes/issues.md) | Advanced filters, status lifecycle, triage patterns |
 | Create or edit workflow recipes | [recipes/workflows.md](recipes/workflows.md) | Lifecycle commands, metadata files, template workflow patterns |
+| Create or manage workflow alerts | [recipes/workflow-alerts.md](recipes/workflow-alerts.md) | Basic and SLO alerts on charts; multi-tier patterns; UI limitations; required values checklist |
+| Create or manage issue alerts | [recipes/issue-alerts.md](recipes/issue-alerts.md) | Alerts on crash/error volume: event thresholds, rate-of-change, device/session counts, new-issue notifications. "Issues" is bitdrift's crash reporting feature — use this for crash alerts |
 | Manage API keys, SDK keys, connectors | [recipes/admin.md](recipes/admin.md) | Key creation, permissions, connector setup |
 
 ## Output modes
@@ -354,4 +356,4 @@ If commands fail or behave unexpectedly:
 When reporting CLI issues, include the OS, how `bd` was installed, whether `bd auth` works, and any
 relevant `npx skills check` output if skills are involved.
 
-**Web UI–only features (no CLI equivalent):** Alerts (Basic + SLO), Session Replay, Saved Views on issues. Point users to the web UI for these.
+**Web UI–only features (no CLI equivalent):** Session Replay, Saved Views (Issue Views). The CLI can attach alerts to an existing Issue View by ID, but cannot create or manage views themselves. Point users to the web UI for these.

--- a/skills/bd-cli/recipes/issue-alerts.md
+++ b/skills/bd-cli/recipes/issue-alerts.md
@@ -1,0 +1,245 @@
+# Issue Alerts
+
+Issue alerts attach to **Issue Views** (saved filtered views of crash/error groups). They fire
+based on the volume, frequency, or trend of issues matching the view's filters.
+
+> **Not to be confused with Workflow Alerts** (`bd workflow alert`) which attach to metric chart
+> time series. See [workflow-alerts.md](./workflow-alerts.md).
+
+---
+
+## Concepts
+
+An **Issue View** is a saved filter over issue groups — scoped by app ID, platform, time range,
+app version, custom event fields, feature flag exposures, or any other issue field. Views are
+visible in the Issues UI at `/issues`.
+
+Issue alerts have three components:
+1. **New-issue notifications** — fire when a new issue event or issue group appears in the view
+2. **Threshold/condition alerts** — fire when issue volume meets a compound condition
+3. **Notification channels** — optional routing to Slack, PagerDuty, etc.
+
+---
+
+## CLI Commands
+
+```bash
+# List all issue alerts
+bd issue alert list --all
+
+# List alerts for a specific view
+bd issue alert list --view-id <VIEW_ID>
+
+# List only firing alerts
+bd issue alert list --firing
+
+# Get alert config for a view
+bd issue alert config <VIEW_ID> -o json
+
+# Create/update alerts on a view
+bd issue alert upsert <VIEW_ID> [flags]
+
+# Delete all alerts on a view
+bd issue alert upsert <VIEW_ID> --delete
+
+# Alert history
+bd issue alert history <VIEW_ID> <ALERT_UUID> --last 7d
+```
+
+---
+
+## New-Issue Notifications
+
+These are simple event-driven notifications — no threshold logic. They fire (rate-limited)
+whenever the view sees activity.
+
+| Type | Fires when... | API field |
+|---|---|---|
+| New issue event | Any error in the view occurs | `new_issue_event_notification` |
+| New issue group | A previously-unseen error type appears in the view | `new_issue_group_notification` |
+
+Both accept a rate limit (`min_time_between_notifications`). Allowed values: `5m`, `15m`, `1h`.
+
+```bash
+# Notify on every new issue event (rate-limited to 1h)
+bd issue alert upsert <VIEW_ID> \
+  --new-issue-event-notification "group=Mobile Alerts,min_interval=1h"
+
+# Notify on new issue groups (rate-limited to 5m)
+bd issue alert upsert <VIEW_ID> \
+  --new-issue-group-notification "group=Mobile Alerts,min_interval=5m"
+```
+
+---
+
+## Condition-Based Alerts
+
+These fire when issue volume meets a threshold. Created via the `--alert` flag, which uses a
+pipe-separated (`|`) key=value format with a `condition=` expression.
+
+### `--alert` flag format
+
+```
+--alert "alert_uuid=<UUID>|name=<NAME>|condition=<EXPR>|notification=<SPEC>|per_issue_group=<BOOL>"
+```
+
+| Key | Required | Description |
+|---|---|---|
+| `alert_uuid` | yes | Unique identifier (use a UUID; for new alerts generate one) |
+| `name` | yes | Human-readable alert name |
+| `condition` | yes | Condition expression (see below) |
+| `description` | no | Alert description |
+| `notification` | no | Notification spec (`group=<NAME>,min_interval=<DUR>`) — repeatable |
+| `per_issue_group` | no | `true` to evaluate per issue group, `false` (default) for across all |
+| `disabled` | no | `true` to create in disabled state |
+| `label` | no | Key=value label (`KEY=VALUE`) — repeatable |
+
+### Condition expressions
+
+Conditions use a function-call syntax: `name(key=value,key=value)`.
+
+#### Event count threshold
+
+"Errors in this view occur frequently" — fires when event count exceeds threshold in a window.
+
+```
+event-threshold(count=100,duration=1h)
+```
+
+#### Unique device threshold
+
+Same as event threshold but counts distinct devices.
+
+```
+unique-device-threshold(count=50,duration=1h)
+```
+
+#### Unique session threshold
+
+Counts distinct sessions.
+
+```
+unique-session-threshold(count=50,duration=1h)
+```
+
+#### Event-to-app-open percentage
+
+Fires when events as a percentage of total app opens exceeds threshold.
+
+```
+event-to-app-open-threshold(percent=0.5,duration=1h)
+```
+
+#### Sessions affected percentage
+
+"Errors in this view are trending up" — fires when the percentage of affected sessions
+(relative to total sessions for the app_id in the window) exceeds threshold.
+
+**Important:** The percentage is calculated against the gross total sessions for the app_id in
+the time window, **ignoring other view filters** (like app version). This means a 1% threshold
+means 1% of ALL sessions, not 1% of filtered sessions.
+
+```
+event-unique-sessions-to-overall-unique-sessions-threshold(percent=1.0,duration=1h)
+```
+
+#### Devices affected percentage
+
+Same concept as sessions but for unique devices.
+
+```
+event-unique-devices-to-overall-unique-devices-threshold(percent=1.0,duration=1h)
+```
+
+#### Rate of change
+
+Fires when the metric changes by an absolute or percentage amount in a window.
+
+```
+event-rate-of-change(window=1h,percentage_change=50,direction=increase)
+event-rate-of-change(window=1h,absolute_change=100,direction=increase)
+```
+
+#### Compound conditions (AND/OR)
+
+Combine multiple conditions with `and(...)` or `or(...)`. Child conditions are separated by `;`.
+
+```
+and(event-threshold(count=100,duration=1h);unique-device-threshold(count=50,duration=1h))
+```
+
+---
+
+## Examples
+
+### Alert on high event volume for a release
+
+```bash
+bd issue alert upsert <VIEW_ID> \
+  --alert "alert_uuid=$(uuidgen)|name=iOS v273 Crash Spike|condition=event-threshold(count=500,duration=1h)|notification=group=Mobile Alerts,min_interval=5m"
+```
+
+### Alert when >1% of sessions are affected
+
+```bash
+bd issue alert upsert <VIEW_ID> \
+  --alert "alert_uuid=$(uuidgen)|name=iOS Session Impact >1%|condition=event-unique-sessions-to-overall-unique-sessions-threshold(percent=1.0,duration=1h)|notification=group=Mobile Alerts,min_interval=15m"
+```
+
+### Per-issue-group alert with compound condition
+
+```bash
+bd issue alert upsert <VIEW_ID> \
+  --alert "alert_uuid=$(uuidgen)|name=High-impact single issue|per_issue_group=true|condition=and(event-threshold(count=100,duration=1h);unique-device-threshold(count=50,duration=1h))|notification=group=Mobile Alerts,min_interval=5m"
+```
+
+### Combined: new-issue notifications + threshold alert
+
+```bash
+bd issue alert upsert <VIEW_ID> \
+  --new-issue-group-notification "group=Mobile Alerts,min_interval=5m" \
+  --alert "alert_uuid=$(uuidgen)|name=Crash volume spike|condition=event-threshold(count=1000,duration=1h)|notification=group=Mobile Alerts,min_interval=15m"
+```
+
+---
+
+## Workflow: Creating Issue Alerts
+
+1. **Identify or ask the user to create a saved Issue View** in the UI with the desired filters
+   (app, platform, version, time range). Views cannot be created via the CLI.
+2. **Get the view ID** — ask the user to copy it from the browser URL when viewing the saved
+   view (the ID is the path segment after `/issues/views/`). If the view already has alerts,
+   you can also find it via:
+   ```bash
+   bd issue alert list --all -o json --jq '[.items[] | {view_id, view_name}]'
+   ```
+   Note: this only returns views that already have alerts attached — it cannot discover views
+   with no alerts.
+3. **Discover notification groups** — list available groups to offer the user a choice:
+   ```bash
+   bd notification-group list -o json --jq '[.notification_groups[] | .name]'
+   ```
+4. **Decide on conditions** — prompt the user:
+   - Do they want notifications on new issues, volume thresholds, or both?
+   - What count/percentage threshold makes sense? (Check current volume in the view)
+   - Scope: across all issues or per issue group?
+   - Rate limit for notifications? (Allowed: `5m`, `15m`, `1h`)
+5. **Create the alert(s)** using `bd issue alert upsert`.
+
+---
+
+## Pitfalls
+
+- **Session/device percentage ignores view filters.** The denominator is ALL sessions/devices
+  for the app_id in the window — not filtered sessions. A 1% threshold on a view filtered to
+  one version means 1% of all sessions across all versions.
+- **`alert_uuid` must be unique.** Use `uuidgen` to generate. If you reuse a UUID, it updates
+  the existing alert.
+- **Pipe delimiter in `--alert`.** The `|` character separates top-level keys. Nested expressions
+  use `,` and `;` — do not use `|` inside conditions.
+- **`--new-issue-event-notification` uses the same format as workflow alert notifications:**
+  `"group=<NAME>,min_interval=<DURATION>"`.
+- **Upserting replaces the entire config.** When updating, pass all alerts and notifications —
+  omitted ones will be removed.
+- **`per_issue_group=true`** evaluates the condition independently for each issue group in the
+  view. Without it, the condition applies to the aggregate across all issue groups.

--- a/skills/bd-cli/recipes/workflow-alerts.md
+++ b/skills/bd-cli/recipes/workflow-alerts.md
@@ -1,0 +1,347 @@
+# Workflow Alerts
+
+Workflow alerts fire when a metric chart breaches a threshold. They attach to a specific time
+series (`aggregated_action_id`) within a workflow's chart action. There are two workflow alert
+types: **basic** and **SLO**.
+
+> **Not to be confused with Issue Alerts** (`bd issue alert`) which attach to Issue Views and
+> support different condition types (event thresholds, rate-of-change, device/session counts).
+> See [issue-alerts.md](./issue-alerts.md).
+
+---
+
+## Prerequisites
+
+Before creating alerts, confirm:
+
+1. **A deployed workflow with a metric chart action exists.** If not, create and deploy one first
+   (see [workflows.md](./workflows.md)).
+2. **You have the workflow ID, chart rule ID, and aggregated action ID.** Extract them:
+   ```bash
+   bd workflow describe <WORKFLOW_ID> -o json --jq '.workflow.actions[] | {
+     rule_id,
+     series: [.metric_chart_rule.time_series[] | .aggregated_id]
+   }'
+   ```
+3. **Notification groups exist** (optional but recommended). Alerts without notification groups
+   still fire and appear in the alerts UI, but won't route to Slack, PagerDuty, SNS, or Datadog.
+   Configure groups first:
+   ```bash
+   bd notification-group list
+   bd notification-group upsert --help
+   ```
+
+### Required values to confirm with the user
+
+**For basic alerts:** threshold value, threshold condition (above/below), time window,
+consecutive data points, unique devices affected, and optionally notification channels.
+
+**For SLO alerts:** SLO window (error budget period), SLO target (e.g. 99.9%), and optionally
+notification channels (global or per-burn-rate-window overrides).
+
+If any required values are missing, prompt the user before proceeding.
+
+### Suggesting thresholds from historical data
+
+When the user asks to add an alert to an existing chart but does not specify a threshold or SLO
+target, **analyze the chart data** to suggest reasonable values:
+
+```bash
+# Pull the last 7 days of chart data
+bd workflow charts <WORKFLOW_ID> -o json --last 7d --jq '.data[].line_data.time_series[] | {
+  labels,
+  rollup: .aggregated_rollup,
+  min: .min,
+  max: .max
+}'
+```
+
+Use the historical baseline to recommend thresholds:
+- **Basic alerts:** suggest a warning threshold at ~1.5× the recent steady-state value, critical
+  at ~2×, and sustained at ~2.5×. Adjust based on variance — high-variance metrics need wider
+  bands to avoid noise.
+- **SLO targets:** derive from the observed success rate over 7–30 days. If the metric has been
+  at 99.95% for the past 30 days, suggest 99.5% as a conservative target — this gives
+  meaningful error budget while still catching real regressions. A tighter target like 99.9%
+  is appropriate only when the team has high confidence and wants early warning.
+
+Present suggested values to the user for confirmation. Do not blindly apply them.
+
+**Recommend periodic review:** After creating alerts, suggest to the user that they should
+periodically (e.g. monthly or quarterly) have the agent review current thresholds against recent
+data to ensure they remain sensible. Thresholds that once made sense can drift — either causing
+alert fatigue (too tight) or missing real incidents (too loose) as traffic patterns, baselines, or
+product behavior change over time.
+
+---
+
+## UI Limitations
+
+- The workflow UI (`/workflow/<id>`) only shows **one alert** per chart in the advanced settings
+  menu. You cannot add additional alerts to a chart via the UI once one exists.
+- **All alerts are visible** in the dedicated alerts UI at `/alerting`.
+- The CLI has no such limitation — multiple alerts per chart (per `aggregated_action_id`) are
+  fully supported. Use the CLI to create multi-alert setups (e.g., warning/critical/sustained
+  tiers, or one alert per series on a multi-series chart).
+
+---
+
+## Listing and Inspecting Alerts
+
+```bash
+# List all alerts in the account
+bd workflow alert list --all
+
+# List only firing alerts
+bd workflow alert list --firing
+
+# Get full config for alerts on a specific chart
+bd workflow alert config <WORKFLOW_ID> <CHART_RULE_ID> -o json
+```
+
+### Alert history
+
+```bash
+bd workflow alert history --help
+```
+
+---
+
+## Basic Alerts
+
+A basic alert fires when a metric crosses a threshold within a rolling time window.
+
+### Key fields
+
+| Field | Description |
+|---|---|
+| `threshold` | Raw numeric value. For rate charts displayed as %, use the decimal (0.05 = 5%). |
+| `condition` | `ABOVE` or `BELOW` |
+| `window` | Rolling evaluation window as a duration string (e.g. `3600s` = 1 hour) |
+| `consecutive_data_points` | Number of consecutive windows that must breach before firing. Omit for single-window alerts. |
+| `unique_device_threshold` | Minimum distinct devices required in the window before evaluating. Prevents low-traffic noise. |
+| `limit_strategy` | Controls which series to evaluate when the chart is grouped. `top_k_limit` evaluates only the top-K series by the sort order. |
+
+### Creating a basic alert
+
+```bash
+bd workflow alert upsert <WORKFLOW_ID> <CHART_RULE_ID> <AGGREGATED_ACTION_ID> \
+  --name "iOS | Crash Rate | Warning (>0.5%)" \
+  --description "Fires when crash rate exceeds 0.5% over a 1h window with 1000+ devices." \
+  --type basic \
+  --threshold 0.005 \
+  --threshold-condition above \
+  --basic-window 1h \
+  --unique-device-threshold 1000 \
+  --notification "group=BitDrift Alerts,min_interval=5m"
+```
+
+### Multi-tier escalation pattern
+
+A common pattern for release-gate alerts: warning → critical → sustained, with escalating
+device thresholds and consecutive data point requirements.
+
+```bash
+# Warning — fires immediately with low device count
+bd workflow alert upsert <WF> <RULE> <AGG> \
+  --name "iOS | Release Gate | Crash | Warning (>0.5%)" \
+  --type basic --threshold 0.005 --threshold-condition above \
+  --basic-window 1h --unique-device-threshold 1000 \
+  --notification "group=Mobile Alerts,min_interval=5m"
+
+# Critical — requires more devices
+bd workflow alert upsert <WF> <RULE> <AGG> \
+  --name "iOS | Release Gate | Crash | Critical (>0.75%)" \
+  --type basic --threshold 0.0075 --threshold-condition above \
+  --basic-window 1h --unique-device-threshold 5000 \
+  --notification "group=Mobile Alerts,min_interval=5m"
+
+# Sustained — requires consecutive breaches and high device count
+bd workflow alert upsert <WF> <RULE> <AGG> \
+  --name "iOS | Release Gate | Crash | Sustained (>1.0%)" \
+  --type basic --threshold 0.01 --threshold-condition above \
+  --basic-window 1h --consecutive-data-points 3 \
+  --unique-device-threshold 10000 \
+  --notification "group=Mobile Alerts,min_interval=5m"
+```
+
+### Multi-series charts
+
+If a chart has multiple time series (e.g. success rate, 4xx rate, 5xx rate), each series has its
+own `aggregated_action_id`. Create separate alerts for each series you want to monitor:
+
+```bash
+bd workflow describe <WF> -o json --jq '.workflow.actions[] |
+  .metric_chart_rule.time_series[] | .aggregated_id'
+```
+
+Then upsert one alert per series using the appropriate `aggregated_action_id`.
+
+### Histogram alerts
+
+For histogram charts (latency distributions), use `--histogram-percentile` to alert on a
+specific percentile:
+
+```bash
+bd workflow alert upsert <WF> <RULE> <AGG> \
+  --name "TTI p95 > 3000ms" \
+  --type basic --threshold 3000 --threshold-condition above \
+  --basic-window 3600s \
+  --histogram-percentile 0.95
+```
+
+---
+
+## SLO Alerts
+
+SLO alerts use multi-window multi-burn-rate alerting. They fire when the rate of error budget
+consumption indicates the SLO will be breached before the window ends.
+
+### Constraints
+
+- **SLOs can only be created on rate charts that do NOT group (split) by a dimension.** If
+  the chart uses `group_by`, you cannot attach an SLO alert. Create a separate ungrouped
+  workflow for SLO monitoring if needed.
+- Each burn-rate window can route to a different notification group, or they can all share one.
+
+### Key fields
+
+| Field | Description |
+|---|---|
+| `slo_duration` | Error budget window (e.g. `720h` = 30 days) |
+| `slo_target` | Target as a decimal (0.999 = 99.9%) |
+| `window_and_burn_rates` | Array of burn-rate windows, each with long window, short window, and burn rate |
+
+### Default burn-rate thresholds
+
+The UI provides these defaults based on the Google SRE Handbook. **The CLI does not offer
+defaults** — configure them explicitly:
+
+| Long Window | Short Window | Burn Rate | Error Budget Consumed |
+|---|---|---|---|
+| 1h | 5min | 16.8 | 10% |
+| 6h | 30min | 5.6 | 20% |
+| 24h | 2h | 2.8 | 40% |
+
+These represent escalating severity: the 1h/5min window catches fast burns (10% of budget gone
+in 1 hour), while the 24h/2h window catches slow sustained degradation (40% consumed over a day).
+
+### Creating an SLO alert
+
+```bash
+bd workflow alert upsert <WORKFLOW_ID> <CHART_RULE_ID> <AGGREGATED_ACTION_ID> \
+  --name "API Success Rate SLO (99.9% / 30d)" \
+  --description "30-day SLO on API success rate. Multi-burn-rate windows per Google SRE handbook." \
+  --type slo \
+  --slo-duration 30d \
+  --slo-target 0.999 \
+  --slo-window "short=5m,long=1h,burn=16.8" \
+  --slo-window "short=30m,long=6h,burn=5.6" \
+  --slo-window "short=2h,long=24h,burn=2.8" \
+  --notification "group=SRE On-Call,min_interval=5m"
+```
+
+### Per-window notification overrides
+
+Route different burn rates to different channels (e.g. fast-burn pages on-call, slow-burn goes
+to Slack). Use `--slo-window-notification` with a 0-based index matching the `--slo-window` order:
+
+```bash
+bd workflow alert upsert <WF> <RULE> <AGG> \
+  --name "API SLO (99.9% / 30d)" \
+  --type slo \
+  --slo-duration 30d \
+  --slo-target 0.999 \
+  --slo-window "short=5m,long=1h,burn=16.8" \
+  --slo-window "short=30m,long=6h,burn=5.6" \
+  --slo-window "short=2h,long=24h,burn=2.8" \
+  --slo-window-notification "0:group=PagerDuty On-Call,min_interval=5m" \
+  --slo-window-notification "1:group=SRE Slack,min_interval=15m" \
+  --slo-window-notification "2:group=SRE Slack,min_interval=1h"
+```
+
+---
+
+## Updating and Deleting Alerts
+
+### Update an existing alert
+
+Pass `--id` to update rather than create:
+
+```bash
+bd workflow alert upsert <WF> <RULE> <AGG> \
+  --id 367 \
+  --name "Updated alert name" \
+  --threshold 0.02
+```
+
+### Disable an alert
+
+```bash
+bd workflow alert upsert <WF> <RULE> <AGG> --id 367 --disabled
+```
+
+### Delete an alert
+
+```bash
+bd workflow alert upsert <WF> <RULE> <AGG> --id 367 --delete
+```
+
+---
+
+## Workflow: Adding Alerts to an Existing Workflow
+
+If the user does not specify a workflow, **ask first** rather than searching speculatively:
+- Do you have a specific workflow in mind (name or ID)?
+- Would you like to create a new workflow for this?
+- Or would you like me to search for a workflow that might match?
+
+Once you have a workflow ID:
+
+1. **Describe the workflow** to get the chart rule ID and aggregated action ID(s):
+   ```bash
+   bd workflow describe <WF> -o json --jq '.workflow.actions[] | {
+     rule_id, series: [.metric_chart_rule.time_series[] | .aggregated_id]
+   }'
+   ```
+2. **Check existing alerts** on that chart:
+   ```bash
+   bd workflow alert config <WF> <CHART_RULE_ID> -o json
+   ```
+3. **Confirm required values with the user** (see Prerequisites above).
+4. **Create the alert(s)** using `bd workflow alert upsert`.
+
+## Workflow: Creating a New Workflow + Alerts
+
+1. **Create and deploy the workflow** (see [workflows.md](./workflows.md)).
+2. **Wait for deployment** — alerts cannot be attached until the workflow is `LIVE`.
+3. **Extract IDs** from the deployed workflow:
+   ```bash
+   bd workflow describe <NEW_WF_ID> -o json --jq '.workflow.actions[] | {
+     rule_id, series: [.metric_chart_rule.time_series[] | .aggregated_id]
+   }'
+   ```
+4. **Confirm required values with the user.**
+5. **Create the alert(s).**
+
+---
+
+## Pitfalls
+
+- **Threshold units:** Rate charts display percentages but alert thresholds use raw decimals.
+  0.05 = 5%, not 0.05%.
+- **SLO + group_by incompatibility:** If you need both version-level breakdown and SLO alerting,
+  create two separate workflows — one grouped for visibility, one ungrouped for the SLO.
+- **Notification groups must exist first.** If you reference a group name that doesn't exist,
+  the upsert will fail. List available groups with `bd notification-group list`.
+- **Durations use humantime format:** `5m`, `30m`, `1h`, `6h`, `24h`, `7d`, `30d`. The API
+  returns seconds with nanosecond precision (`3600.000000000s`) but the CLI accepts human-readable
+  strings.
+- **`--notification` format:** `"group=<NAME>,min_interval=<DURATION>"` — `min_interval` is
+  optional (controls rate-limiting between repeated notifications).
+- **`--slo-window` format:** `"short=<DURATION>,long=<DURATION>,burn=<FLOAT>"` — key=value
+  pairs, comma-separated.
+- **`--slo-window-notification` format:** `"<INDEX>:group=<NAME>,min_interval=<DURATION>"` —
+  0-based index matching the order of `--slo-window` flags.
+- **Updating an alert replaces the full config.** Pass all desired fields on update, not just
+  the changed ones.


### PR DESCRIPTION
Adds two new recipe files to the bd-cli skill covering alert creation and management via the CLI.

## Changes

- **`recipes/workflow-alerts.md`** — Basic + SLO alerts on workflow chart time series. Covers multi-tier escalation patterns, threshold suggestions from historical data, Google SRE burn-rate defaults, per-window notification overrides, and pitfalls.
- **`recipes/issue-alerts.md`** — Issue View alerts for crash/error monitoring. Covers event thresholds, rate-of-change, device/session counts, new-issue notifications, compound AND/OR conditions, and per-issue-group scoping.
- **`SKILL.md`** — Updated domain routing table with both alert recipes. Removed alerts from the web-UI-only features note. Clarified that Session Replay and Saved Views remain UI-only.